### PR TITLE
move rioja to imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,6 @@ Suggests: testthat,
     knitr,
     mudata2,
     rmarkdown,
-    rioja,
     vegan,
     glue,
     ggrepel,
@@ -38,5 +37,6 @@ Imports: rlang,
     graphics,
     grDevices,
     tidyr,
-    digest
+    digest,
+    rioja
 VignetteBuilder: knitr


### PR DESCRIPTION
Because it's use in exported fns, so it's a smoother experience for the user to have it installed when the pkg is installed, rather than get an error when using `nested_chclust_coniss()` etc. if rioja is not yet installed.