### PR TITLE
Unname selections to ensure they don't look like renames

### DIFF
--- a/R/nested_data_matrix.R
+++ b/R/nested_data_matrix.R
@@ -53,10 +53,10 @@ nested_data <- function(.data, qualifiers = NULL, key = NULL, value, fill = NA,
   }
 
   # this makes sure all args refer to valid columns, enables checking names later
-  group_vars <- tidyselect::vars_select(colnames(.data), !!groups)
-  qualifier_vars <- tidyselect::vars_select(colnames(.data), !!qualifiers)
-  key_vars <- tidyselect::vars_select(colnames(.data), !!key)
-  value_vars <- tidyselect::vars_select(colnames(.data), !!value)
+  group_vars <- unname(tidyselect::vars_select(colnames(.data), !!groups))
+  qualifier_vars <- unname(tidyselect::vars_select(colnames(.data), !!qualifiers))
+  key_vars <- unname(tidyselect::vars_select(colnames(.data), !!key))
+  value_vars <- unname(tidyselect::vars_select(colnames(.data), !!value))
 
   # key, qualifier, and group vars can't intersect
   stopifnot(


### PR DESCRIPTION
Hi @paleolimbot,

We ran revdeps for the upcoming release of tidyr 1.3.0 and your package came up.

In dev tidyr we have becoming slightly stricter and now error if you try to provide a named tidy-selection to functions like `nest()`. In the best case, this previously had no effect even though it "looked" like renaming was being requested. In the worst cases, it actually broke some tidyr functions.

It doesn't look like you were using the "rename" feature in any way, it seems like you only used tidy-selection to allow users to select specific columns, so the easiest thing to do is to just unname.

We plan to release tidyr 1.3.0 on January 23rd.

This patch is backwards compatible with CRAN tidyr. If you could go ahead and release a version of your package to CRAN with this patch, then it would help us out a lot when we release tidyr. Thanks!